### PR TITLE
Fix - filling the size of the parent element

### DIFF
--- a/src/data-display/card/index.mdx
+++ b/src/data-display/card/index.mdx
@@ -76,8 +76,7 @@ Eventualmente é desejável criar um cartão somente com o conteúdo sendo poss�
 
 ### Cartão `Hoverable`
 
-Cartão com sentença de sopreposição.  
-Usado para quando o cartão possa ser utilizado(por exemplo, acessar um link).
+Cartão com sentença de sopreposição. Usado para quando o cartão possa ser utilizado(por exemplo, acessar um link).
 
 <Playground>
   <a href="#" style={{ textDecoration: "none" }}>
@@ -111,8 +110,7 @@ Usado para quando o cartão possa ser utilizado(por exemplo, acessar um link).
 
 ### Mais configurações ao conteúdo
 
-Ademais você ainda pode adicionar `footer` suportando um conteúdo ainda mais flexível.  
-Como os exemplos abaixo, utilizando um `node` completo no conteúdo e rodapé com botões:
+Ademais você ainda pode adicionar `footer` suportando um conteúdo ainda mais flexível. Como os exemplos abaixo, utilizando um `node` completo no conteúdo e rodapé com botões:
 
 <Playground>
   <Card
@@ -167,6 +165,38 @@ Como os exemplos abaixo, utilizando um `node` completo no conteúdo e rodapé co
       labore amet aliquip.
     </div>
   </Card>
+  <div style={{ display: "flex", alignItems: "center" }}>
+    <Card>
+      <table style={{ width: "100%" }}>
+        <thead style={{ textAlign: "left" }}>
+          <th>Execution date</th>
+          <th>Total invoices to process</th>
+          <th>Processed invoices</th>
+          <th>Status</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>22/07/2021</td>
+            <td>27.000</td>
+            <td>27.000</td>
+            <td>
+              <span
+                style={{
+                  backgroundColor: "limegreen",
+                  color: "white",
+                  padding: 4,
+                  borderRadius: 2
+                }}
+              >
+                Sucess
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </Card>
+    <Button type="primary">Other element</Button>
+  </div>
 </Playground>
 
 ## API

--- a/src/data-display/card/styles.js
+++ b/src/data-display/card/styles.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 
 export const CardStyle = styled.div`
+  width: 100%;
+  height: 100%;
   box-sizing: border-box;
   margin-bottom: 10px;
   padding: 0;


### PR DESCRIPTION
### Card size outside of default behavior

> The behavior should be:  
Card must fill the space offered by the parent element
---
After changes in **Branch**: fix/card-size   
![image](https://user-images.githubusercontent.com/66069923/126653784-a46b3135-99f6-4334-9d12-c0373dc4d9ee.png)
![image](https://user-images.githubusercontent.com/66069923/126663270-a1308489-7ad6-4b53-b2df-3c52d4486efe.png)
